### PR TITLE
run GH workflow on push too

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@ env:
   CC_TEST_REPORTER_ID: ${{ secrets.CC_TEST_REPORTER_ID }}
 
 name: Continuous Integration
-on: [pull_request]
+on: [push, pull_request]
 
 jobs:
   test:


### PR DESCRIPTION
In order to make the Test Coverage work, we need to run the GH workflow on `main` branch too.