### PR TITLE
Update rubocop_configuration_path.rb

### DIFF
--- a/lib/ruboclean/rubocop_configuration_path.rb
+++ b/lib/ruboclean/rubocop_configuration_path.rb
@@ -41,7 +41,7 @@ module Ruboclean
     end
 
     def load_yaml
-      YAML.safe_load(@rubocop_configuration_path.read)
+      YAML.safe_load(@rubocop_configuration_path.read, [Symbol, Regexp])
     end
   end
 end


### PR DESCRIPTION
Allow ruby 3.0 un-authorized classes.