### PR TITLE
preserve comments

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,8 +30,9 @@ AllCops:
   Exclude:
   - bin/**/*
 
+# Preceding comments will be removed unless the --preserve-comments option is used.
 require:
-- rubocop-rails
+- rubocop-rails # Inline comments will always be removed.
 ```
 
 ### Output `.rubocop.yml`:
@@ -54,9 +55,7 @@ Layout/LineLength:
 
 Rails/ShortI18n:
   Enabled: true
-
 ```
-
 
 ## Installation
 
@@ -78,27 +77,24 @@ Or install it yourself as:
 gem install ruboclean
 ```
 
-## Usage
+## Command synopsis
 
 ```shell
-ruboclean [path]
+ruboclean [path] [--preserve-comments]
 ```
 
-* `path` is optional, it defaults to the current working directory
-* `path` can be a directory that contains a `.rubocop.yml`
-* `path` can be a path to a `.rubocop.yml` directly
+### Parameters
+
+| Parameter | Description |
+|:-|:-|
+| `path` | Can be a directory that contains a `.rubocop.yml`, or a path to a `.rubocop.yml` directly. Defaults to the current working directory.  |
+| `--preserve-comments` |  Preserves **preceding** comments for each top-level entry in the configuration. Inline comments are **not** preserved. |
 
 ### Examples
 
 ```shell
-ruboclean                 # uses `.rubocop.yml` of current working directory
-```
-
-```shell
-ruboclean /path/to/dir    # uses `.rubocop.yml` of /path/to/dir
-```
-
-```shell
+ruboclean                             # uses `.rubocop.yml` of current working directory
+ruboclean /path/to/dir                # uses `.rubocop.yml` of /path/to/dir
 ruboclean /path/to/dir/.rubocop.yml
 ```
 
@@ -111,7 +107,6 @@ To install this gem onto your local machine, run `bundle exec rake install`. To 
 ## Contributing
 
 Bug reports and pull requests are welcome on GitHub at https://github.com/lxxxvi/ruboclean. This project is intended to be a safe, welcoming space for collaboration, and contributors are expected to adhere to the [code of conduct](https://github.com/lxxxvi/ruboclean/blob/master/CODE_OF_CONDUCT.md).
-
 
 ## License
 

--- a/lib/ruboclean/arguments.rb
+++ b/lib/ruboclean/arguments.rb
@@ -16,7 +16,11 @@ module Ruboclean
     end
 
     def silent?
-      @silent ||= find_silent
+      @silent ||= find_argument("--silent")
+    end
+
+    def preserve_comments?
+      @preserve_comments ||= find_argument("--preserve-comments")
     end
 
     private
@@ -31,10 +35,8 @@ module Ruboclean
       end
     end
 
-    def find_silent
-      command_line_arguments.any? do |argument|
-        argument == "--silent"
-      end
+    def find_argument(name)
+      command_line_arguments.any? { |argument| argument == name }
     end
   end
 end

--- a/lib/ruboclean/runner.rb
+++ b/lib/ruboclean/runner.rb
@@ -13,7 +13,7 @@ module Ruboclean
 
       return if rubocop_configuration.nil?
 
-      rubocop_configuration_path.write(rubocop_configuration.order)
+      rubocop_configuration_path.write(rubocop_configuration.order, preserve_comments: arguments.preserve_comments?)
     end
 
     private

--- a/test/fixtures/00_expected_output_with_preserved_comments.yml
+++ b/test/fixtures/00_expected_output_with_preserved_comments.yml
@@ -1,0 +1,31 @@
+---
+
+# preceding inherit_from: comment
+inherit_from:
+- shared.yml
+
+# preceding require: comment, wrongly indented
+require:
+- rubocop-rails
+
+# multiline
+
+# preceding AllCops: comment, with newline gap
+
+AllCops:
+  Exclude:
+  - bin/**/*
+  - !ruby/regexp /old_and_unused\.rb$/
+
+# preceding Rails: comment, empty line in between
+
+Rails:
+  Enabled: true
+
+Layout/LineLength:
+  Max: 120
+
+# multiline
+# preceding Rails/ShortI18n: comment
+Rails/ShortI18n:
+  Enabled: true

--- a/test/fixtures/00_input.yml
+++ b/test/fixtures/00_input.yml
@@ -1,19 +1,30 @@
+# multiline
+# preceding Rails/ShortI18n: comment
 Rails/ShortI18n:
   Enabled: true
 
 Layout/LineLength:
+# this comment should be removed
   Max: 120
+# preceding Rails: comment, empty line in between
 
 Rails:
   Enabled: true
+
+# multiline
+
+# preceding AllCops: comment, with newline gap
 
 AllCops:
   Exclude:
   - bin/**/*
   - !ruby/regexp /old_and_unused\.rb$/
 
+  # preceding require: comment, wrongly indented
 require:
 - rubocop-rails
 
+
+# preceding inherit_from: comment
 inherit_from:
 - shared.yml

--- a/test/ruboclean/arguments_test.rb
+++ b/test/ruboclean/arguments_test.rb
@@ -9,6 +9,7 @@ module Ruboclean
         assert_equal Dir.pwd.to_s, arguments.path
         assert_predicate arguments, :verbose?
         refute_predicate arguments, :silent?
+        refute_predicate arguments, :preserve_comments?
       end
     end
 
@@ -21,6 +22,13 @@ module Ruboclean
         assert_equal Dir.pwd.to_s, arguments.path
         refute_predicate arguments, :verbose?
         assert_predicate arguments, :silent?
+      end
+    end
+
+    def test_preserve_comments
+      Ruboclean::Arguments.new(["--preserve-comments"]).tap do |arguments|
+        assert_equal Dir.pwd.to_s, arguments.path
+        assert_predicate arguments, :preserve_comments?
       end
     end
   end

--- a/test/ruboclean_test.rb
+++ b/test/ruboclean_test.rb
@@ -21,7 +21,7 @@ class RubocleanTest < BaseTest
 
   def test_run_from_cli_with_path_to_configuration_directory
     using_fixture_file("00_input.yml") do |fixture_path, directory_path|
-      Ruboclean.run_from_cli!(Array(directory_path))
+      Ruboclean.run_from_cli!([directory_path, "--silent"])
 
       assert_equal fixture_file_path("00_expected_output.yml").read,
                    Pathname.new(fixture_path).read
@@ -30,7 +30,7 @@ class RubocleanTest < BaseTest
 
   def test_run_from_cli_with_path_to_configuration_file
     using_fixture_file("00_input.yml") do |fixture_path|
-      Ruboclean.run_from_cli!(Array(fixture_path))
+      Ruboclean.run_from_cli!([fixture_path, "--silent"])
 
       assert_equal fixture_file_path("00_expected_output.yml").read,
                    Pathname.new(fixture_path).read
@@ -40,7 +40,7 @@ class RubocleanTest < BaseTest
   def test_run_from_cli_without_silent_option
     using_fixture_file("02_input_empty.yml") do |fixture_path|
       assert_output(/^Using path '.*' \.\.\. done.$/) do
-        Ruboclean.run_from_cli!(Array(fixture_path))
+        Ruboclean.run_from_cli!([fixture_path])
       end
     end
   end
@@ -50,6 +50,15 @@ class RubocleanTest < BaseTest
       assert_output(/^$/) do
         Ruboclean.run_from_cli!([fixture_path, "--silent"])
       end
+    end
+  end
+
+  def test_run_preserve_comments
+    using_fixture_file("00_input.yml") do |fixture_path|
+      Ruboclean.run_from_cli!([fixture_path, "--silent", "--preserve-comments"])
+
+      assert_equal fixture_file_path("00_expected_output_with_preserved_comments.yml").read,
+                   Pathname.new(fixture_path).read
     end
   end
 end


### PR DESCRIPTION
As requested in #23, this PR introduces the `--preserve-comments` flag. It allows to preserve preceding comments in a configuration file. However, it does **not** preserve inline comments. Example:

```yaml
--- 

Foo:
  - something # inline comment about Foo.something

# Comment about Bar
Bar:
  - else
```

`ruboclean --preserve-comments`


```yaml
--- 

# Comment about Bar
Bar:
  - else

Foo:
  - something
```
