### PR TITLE
Check that `Include` and `Exclude` paths exist

### DIFF
--- a/lib/ruboclean.rb
+++ b/lib/ruboclean.rb
@@ -6,6 +6,7 @@ require "ruboclean/rubocop_configuration"
 require "ruboclean/rubocop_configuration_path"
 require "ruboclean/runner"
 require "ruboclean/orderer"
+require "ruboclean/path_cleanup"
 
 # Ruboclean entry point
 module Ruboclean

--- a/lib/ruboclean/path_cleanup.rb
+++ b/lib/ruboclean/path_cleanup.rb
@@ -22,11 +22,10 @@ module Ruboclean
     end
 
     def select_stanzas(kind)
-      @config_hash.each_with_object([]) do |item, result|
-        cop, value = item
+      @config_hash.filter_map do |cop, value|
         next unless value.is_a?(Hash)
 
-        result << cop if value.key?(kind)
+        cop if value.key?(kind)
       end
     end
 

--- a/lib/ruboclean/path_cleanup.rb
+++ b/lib/ruboclean/path_cleanup.rb
@@ -13,7 +13,7 @@ module Ruboclean
     def cleanup
       %i[Include Exclude].each do |kind|
         select_stanzas(kind).each do |cop|
-          paths = @config_hash.dig(cop, kind.to_s) || @config_hash.dig(cop, kind.to_sym)
+          paths = @config_hash.dig(cop, kind)
           paths&.select! { |path| regexp_or_wildcard?(path) || File.exist?(path) }
         end
       end
@@ -26,7 +26,7 @@ module Ruboclean
         cop, value = item
         next unless value.is_a?(Hash)
 
-        result << cop if value.key?(kind.to_s) || value.key?(kind.to_sym)
+        result << cop if value.key?(kind)
       end
     end
 

--- a/lib/ruboclean/path_cleanup.rb
+++ b/lib/ruboclean/path_cleanup.rb
@@ -1,0 +1,37 @@
+# frozen_string_literal: true
+
+module Ruboclean
+  # Cleans up any `Include` or `Exclude` paths that don't exist.
+  # The `Include` and `Exclude` paths are relative to the directory
+  # where the `.rubocop.yml` file is located. If a path includes a
+  # wildcard, it's assumed to be valid.
+  class PathCleanup
+    def initialize(config_hash)
+      @config_hash = config_hash
+    end
+
+    def cleanup
+      %i[Include Exclude].each do |kind|
+        select_stanzas(kind).each do |cop|
+          paths = @config_hash.dig(cop, kind.to_s) || @config_hash.dig(cop, kind.to_sym)
+          paths&.select! { |path| regexp_or_wildcard?(path) || File.exist?(path) }
+        end
+      end
+
+      @config_hash
+    end
+
+    def select_stanzas(kind)
+      @config_hash.each_with_object([]) do |item, result|
+        cop, value = item
+        next unless value.is_a?(Hash)
+
+        result << cop if value.key?(kind.to_s) || value.key?(kind.to_sym)
+      end
+    end
+
+    def regexp_or_wildcard?(path)
+      path.is_a?(Regexp) || path.include?("*")
+    end
+  end
+end

--- a/lib/ruboclean/rubocop_configuration.rb
+++ b/lib/ruboclean/rubocop_configuration.rb
@@ -11,13 +11,13 @@ module Ruboclean
       Ruboclean::Orderer.new(@config_hash).order
     end
 
-    def cleanup
+    def path_cleanup
       Ruboclean::PathCleanup.new(@config_hash).cleanup
     end
 
     def perform
       @config_hash = order
-      cleanup
+      path_cleanup
     end
 
     def nil?

--- a/lib/ruboclean/rubocop_configuration.rb
+++ b/lib/ruboclean/rubocop_configuration.rb
@@ -11,6 +11,15 @@ module Ruboclean
       Ruboclean::Orderer.new(@config_hash).order
     end
 
+    def cleanup
+      Ruboclean::PathCleanup.new(@config_hash).cleanup
+    end
+
+    def perform
+      @config_hash = order
+      cleanup
+    end
+
     def nil?
       @config_hash.nil?
     end

--- a/lib/ruboclean/rubocop_configuration_path.rb
+++ b/lib/ruboclean/rubocop_configuration_path.rb
@@ -6,7 +6,7 @@ require "yaml"
 module Ruboclean
   # Interface for reading and writing the `.rubocop.yml` file
   class RubocopConfigurationPath
-    PERMITTED_CLASSES = [Regexp, Symbol].freeze
+    PERMITTED_CLASSES = [Regexp].freeze
 
     # Thrown if given path is invalid
     class InvalidPathError < StandardError

--- a/lib/ruboclean/rubocop_configuration_path.rb
+++ b/lib/ruboclean/rubocop_configuration_path.rb
@@ -6,7 +6,7 @@ require "yaml"
 module Ruboclean
   # Interface for reading and writing the `.rubocop.yml` file
   class RubocopConfigurationPath
-    PERMITTED_CLASSED = [Regexp].freeze
+    PERMITTED_CLASSES = [Regexp, Symbol].freeze
 
     # Thrown if given path is invalid
     class InvalidPathError < StandardError
@@ -44,7 +44,7 @@ module Ruboclean
     end
 
     def load_yaml
-      YAML.safe_load(source_yaml, permitted_classes: PERMITTED_CLASSED)
+      YAML.safe_load(source_yaml, permitted_classes: PERMITTED_CLASSES)
     end
 
     def source_yaml

--- a/lib/ruboclean/runner.rb
+++ b/lib/ruboclean/runner.rb
@@ -13,7 +13,7 @@ module Ruboclean
 
       return if rubocop_configuration.nil?
 
-      rubocop_configuration_path.write(rubocop_configuration.order, preserve_comments: arguments.preserve_comments?)
+      rubocop_configuration_path.write(rubocop_configuration.perform, preserve_comments: arguments.preserve_comments?)
     end
 
     private

--- a/test/fixtures/file_exists.rb
+++ b/test/fixtures/file_exists.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+# test for path cleanup

--- a/test/fixtures/other_file_exists.rb
+++ b/test/fixtures/other_file_exists.rb
@@ -1,0 +1,2 @@
+# frozen_string_literal: true
+# test for path cleanup

--- a/test/ruboclean/path_cleanup_test.rb
+++ b/test/ruboclean/path_cleanup_test.rb
@@ -20,17 +20,31 @@ module Ruboclean
       assert_equal output, Ruboclean::PathCleanup.new(input).cleanup
     end
 
+    # rubocop:disable Metrics/MethodLength
     def test_path_cleanup_include_and_exclude
       input = {
         SomeCop: {
           Include: ["lib/**/*.rb", "test/fixtures/not_here.rb"],
-          Exclude: ["config/**/*.rb", "test/fixtures/other_file_exists.rb", "some_other_non_existent_file.rb"]
+          Exclude: ["config/**/*.rb", "test/fixtures/other_file_exists.rb", "some_other_non_existent_file.rb"],
+          EnforcedStyle: "something"
+        },
+        SomeOtherCop: {
+          EnforcedStyle: "something"
         }
       }
-      output = { SomeCop: { Include: ["lib/**/*.rb"],
-                            Exclude: ["config/**/*.rb", "test/fixtures/other_file_exists.rb"] } }
+      output = {
+        SomeCop: {
+          Include: ["lib/**/*.rb"],
+          Exclude: ["config/**/*.rb", "test/fixtures/other_file_exists.rb"],
+          EnforcedStyle: "something"
+        },
+        SomeOtherCop: {
+          EnforcedStyle: "something"
+        }
+      }
 
       assert_equal output, Ruboclean::PathCleanup.new(input).cleanup
     end
+    # rubocop:enable Metrics/MethodLength
   end
 end

--- a/test/ruboclean/path_cleanup_test.rb
+++ b/test/ruboclean/path_cleanup_test.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+require "test_helper"
+require "ruboclean/path_cleanup"
+
+module Ruboclean
+  class PathCleanupTest < BaseTest
+    def test_path_cleanup_includes
+      input = { SomeCop: { Include: ["some_other_file.rb", "test/fixtures/file_exists.rb", "lib/**/*.rb"] } }
+      output = { SomeCop: { Include: ["test/fixtures/file_exists.rb", "lib/**/*.rb"] } }
+
+      assert_equal output, Ruboclean::PathCleanup.new(input).cleanup
+    end
+
+    def test_path_cleanup_excludes
+      input = { SomeCop: { Exclude: ["config/**/*.rb", "test/fixtures/other_file_exists.rb",
+                                     "some_other_non_existent_file.rb", "test/fixtures/not_here.rb"] } }
+      output = { SomeCop: { Exclude: ["config/**/*.rb", "test/fixtures/other_file_exists.rb"] } }
+
+      assert_equal output, Ruboclean::PathCleanup.new(input).cleanup
+    end
+
+    def test_path_cleanup_include_and_exclude
+      input = {
+        SomeCop: {
+          Include: ["lib/**/*.rb", "test/fixtures/not_here.rb"],
+          Exclude: ["config/**/*.rb", "test/fixtures/other_file_exists.rb", "some_other_non_existent_file.rb"]
+        }
+      }
+      output = { SomeCop: { Include: ["lib/**/*.rb"],
+                            Exclude: ["config/**/*.rb", "test/fixtures/other_file_exists.rb"] } }
+
+      assert_equal output, Ruboclean::PathCleanup.new(input).cleanup
+    end
+  end
+end

--- a/test/ruboclean/rubocop_configuration_test.rb
+++ b/test/ruboclean/rubocop_configuration_test.rb
@@ -18,7 +18,7 @@ module Ruboclean
       input = { SomeCop: { Include: ["some_other_file.rb", "test/fixtures/file_exists.rb", "lib/**/*.rb"] } }
       output = { SomeCop: { Include: ["test/fixtures/file_exists.rb", "lib/**/*.rb"] } }
 
-      Ruboclean::RubocopConfiguration.new(input).cleanup.tap do |cleaned_output|
+      Ruboclean::RubocopConfiguration.new(input).path_cleanup.tap do |cleaned_output|
         assert_instance_of Hash, cleaned_output
         assert_equal output.to_a, cleaned_output.to_a
       end

--- a/test/ruboclean/rubocop_configuration_test.rb
+++ b/test/ruboclean/rubocop_configuration_test.rb
@@ -14,6 +14,27 @@ module Ruboclean
       end
     end
 
+    def test_path_cleanup
+      input = { SomeCop: { Include: ["some_other_file.rb", "test/fixtures/file_exists.rb", "lib/**/*.rb"] } }
+      output = { SomeCop: { Include: ["test/fixtures/file_exists.rb", "lib/**/*.rb"] } }
+
+      Ruboclean::RubocopConfiguration.new(input).cleanup.tap do |cleaned_output|
+        assert_instance_of Hash, cleaned_output
+        assert_equal output.to_a, cleaned_output.to_a
+      end
+    end
+
+    def test_perform
+      input = { "Rails" => { Exclude: ["does_not_exist.rb", "test/fixtures/file_exists.rb"] },
+                "AllCops" => { Enabled: true } }
+      output = { "AllCops" => { Enabled: true }, "Rails" => { Exclude: ["test/fixtures/file_exists.rb"] } }
+
+      Ruboclean::RubocopConfiguration.new(input).perform.tap do |cleaned_output|
+        assert_instance_of Hash, cleaned_output
+        assert_equal output.to_a, cleaned_output.to_a
+      end
+    end
+
     def test_nil?
       assert_nil Ruboclean::RubocopConfiguration.new(nil)
     end


### PR DESCRIPTION
Hi there! Thanks for building this tool, I really like it! Feel free to take or leave this PR, but I thought it would be useful to add a feature to check that paths really exist.

This adds a `PathCleanup` class that removes any paths in the `Include` and `Exclude` lists that don't exist (relative to the `.rubocop.yml`, ignoring paths with globs).

This is useful for when you have a `.rubocop.yml` file that has been around for a while and has lots of paths that people forget to clean up when they delete the files, so doing so manually would be tedious.
