### PR TITLE
Add verify flag

### DIFF
--- a/README.md
+++ b/README.md
@@ -84,7 +84,7 @@ gem install ruboclean
 ## Command synopsis
 
 ```shell
-ruboclean [path] [--silent] [--preserve-comments] [--preserve-paths]
+ruboclean [path] [--silent] [--preserve-comments] [--preserve-paths] [--verify]
 ```
 
 ### Parameters
@@ -95,6 +95,7 @@ ruboclean [path] [--silent] [--preserve-comments] [--preserve-paths]
 | `--silent`            | Suppress any output displayed on the screen when executing the command.                                                               |
 | `--preserve-comments` | Preserves **preceding** comments for each top-level entry in the configuration. Inline comments are **not** preserved.                |
 | `--preserve-paths`    | Skips the path cleanup that are applied against `Include:` and `Exclude:` configuration.                                              |
+| `--verify`            | Executes in dry-run mode. Exits with 1 if changes are needed, otherwise 0.                                                            |
 
 ### Examples
 

--- a/lib/ruboclean.rb
+++ b/lib/ruboclean.rb
@@ -14,12 +14,24 @@ module Ruboclean
   def self.run_from_cli!(args)
     runner = Runner.new(args)
     logger = Ruboclean::Logger.new(runner.verbose? ? :verbose : :none)
+
     logger.verbose "Using path '#{runner.path}' ... "
-    have_no_change = !runner.run!
+    changed = runner.run!
+    logger.verbose post_execution_message(changed, runner.verify?)
 
-    logger.verbose "done.\n"
-
-    exit have_no_change if runner.verify?
+    exit !changed if runner.verify?
     exit 0
+  end
+
+  def self.post_execution_message(changed, verify)
+    if changed
+      if verify
+        "needs clean.\n"
+      else
+        "done.\n"
+      end
+    else
+      "already clean.\n"
+    end
   end
 end

--- a/lib/ruboclean.rb
+++ b/lib/ruboclean.rb
@@ -2,6 +2,7 @@
 
 require "ruboclean/cli_arguments"
 require "ruboclean/orderer"
+require "ruboclean/logger"
 require "ruboclean/grouper"
 require "ruboclean/path_cleanup"
 require "ruboclean/runner"

--- a/lib/ruboclean.rb
+++ b/lib/ruboclean.rb
@@ -13,7 +13,10 @@ module Ruboclean
   def self.run_from_cli!(args)
     runner = Runner.new(args)
     print "Using path '#{runner.path}' ... " if runner.verbose?
-    runner.run!
+    have_no_change = !runner.run!
     puts "done." if runner.verbose?
+
+    exit have_no_change if runner.verify?
+    exit 0
   end
 end

--- a/lib/ruboclean.rb
+++ b/lib/ruboclean.rb
@@ -13,9 +13,11 @@ require "ruboclean/version"
 module Ruboclean
   def self.run_from_cli!(args)
     runner = Runner.new(args)
-    print "Using path '#{runner.path}' ... " if runner.verbose?
+    logger = Ruboclean::Logger.new(runner.verbose? ? :verbose : :none)
+    logger.verbose "Using path '#{runner.path}' ... "
     have_no_change = !runner.run!
-    puts "done." if runner.verbose?
+
+    logger.verbose "done.\n"
 
     exit have_no_change if runner.verify?
     exit 0

--- a/lib/ruboclean/cli_arguments.rb
+++ b/lib/ruboclean/cli_arguments.rb
@@ -27,6 +27,10 @@ module Ruboclean
       @preserve_paths ||= find_argument("--preserve-paths")
     end
 
+    def verify?
+      @verify ||= find_argument("--verify")
+    end
+
     private
 
     attr_reader :command_line_arguments

--- a/lib/ruboclean/logger.rb
+++ b/lib/ruboclean/logger.rb
@@ -1,7 +1,6 @@
 # frozen_string_literal: true
 
 module Ruboclean
-  # Orders the items within the groups alphabetically
   class Logger
     def initialize(log_level = :verbose)
       raise ArgumentError, "Invalid log level" unless %i[verbose none].include?(log_level)

--- a/lib/ruboclean/logger.rb
+++ b/lib/ruboclean/logger.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 module Ruboclean
+  # Logger for clean management of log levels
   class Logger
     def initialize(log_level = :verbose)
       raise ArgumentError, "Invalid log level" unless %i[verbose none].include?(log_level)

--- a/lib/ruboclean/logger.rb
+++ b/lib/ruboclean/logger.rb
@@ -1,0 +1,19 @@
+# frozen_string_literal: true
+
+module Ruboclean
+  # Orders the items within the groups alphabetically
+  class Logger
+    def initialize(log_level = :verbose)
+      raise ArgumentError, "Invalid log level" unless %i[verbose none].include?(log_level)
+
+      @log_level = log_level
+    end
+
+    def verbose(message)
+      case @log_level
+      when :verbose
+        print message
+      end
+    end
+  end
+end

--- a/lib/ruboclean/runner.rb
+++ b/lib/ruboclean/runner.rb
@@ -18,9 +18,7 @@ module Ruboclean
                      .then(&method(:cleanup_paths))
                      .then(&method(:convert_to_yaml))
 
-      return if verify?
-
-      write_file!(ordered_file)
+      write_file!(ordered_file) unless verify?
 
       changed?(ordered_file)
     end

--- a/lib/ruboclean/runner.rb
+++ b/lib/ruboclean/runner.rb
@@ -21,6 +21,12 @@ module Ruboclean
       return if verify?
 
       write_file!(ordered_file)
+
+      changed?(ordered_file)
+    end
+
+    def changed?(target_yaml)
+      target_yaml != source_yaml
     end
 
     def verbose?

--- a/lib/ruboclean/runner.rb
+++ b/lib/ruboclean/runner.rb
@@ -13,14 +13,22 @@ module Ruboclean
     def run!
       return if source_file_pathname.empty?
 
-      load_file.then(&method(:order))
-               .then(&method(:cleanup_paths))
-               .then(&method(:convert_to_yaml))
-               .then(&method(:write_file!))
+      ordered_file = load_file
+                     .then(&method(:order))
+                     .then(&method(:cleanup_paths))
+                     .then(&method(:convert_to_yaml))
+
+      return if verify?
+
+      write_file!(ordered_file)
     end
 
     def verbose?
       cli_arguments.verbose?
+    end
+
+    def verify?
+      cli_arguments.verify?
     end
 
     def path

--- a/lib/ruboclean/runner.rb
+++ b/lib/ruboclean/runner.rb
@@ -13,14 +13,11 @@ module Ruboclean
     def run!
       return if source_file_pathname.empty?
 
-      ordered_file = load_file
-                     .then(&method(:order))
-                     .then(&method(:cleanup_paths))
-                     .then(&method(:convert_to_yaml))
-
-      write_file!(ordered_file) unless verify?
-
-      changed?(ordered_file)
+      load_file.then(&method(:order))
+               .then(&method(:cleanup_paths))
+               .then(&method(:convert_to_yaml))
+               .then(&method(:write_file!))
+               .then(&method(:changed?))
     end
 
     def changed?(target_yaml)
@@ -66,7 +63,9 @@ module Ruboclean
     end
 
     def write_file!(target_yaml)
-      source_file_pathname.write(target_yaml)
+      target_yaml.tap do |content|
+        source_file_pathname.write(content) unless verify?
+      end
     end
 
     def source_file_pathname

--- a/test/ruboclean/cli_arguments_test.rb
+++ b/test/ruboclean/cli_arguments_test.rb
@@ -10,6 +10,7 @@ module Ruboclean
         assert_predicate cli_arguments, :verbose?
         refute_predicate cli_arguments, :silent?
         refute_predicate cli_arguments, :preserve_comments?
+        refute_predicate cli_arguments, :verify?
       end
     end
 
@@ -36,6 +37,13 @@ module Ruboclean
       Ruboclean::CliArguments.new(["--preserve-paths"]).tap do |cli_arguments|
         assert_equal Dir.pwd.to_s, cli_arguments.path
         assert_predicate cli_arguments, :preserve_paths?
+      end
+    end
+
+    def test_verify
+      Ruboclean::CliArguments.new(["--verify"]).tap do |cli_arguments|
+        assert_equal Dir.pwd.to_s, cli_arguments.path
+        assert_predicate cli_arguments, :verify?
       end
     end
   end

--- a/test/ruboclean/logger_test.rb
+++ b/test/ruboclean/logger_test.rb
@@ -1,0 +1,23 @@
+# frozen_string_literal: true
+
+require "test_helper"
+
+module Ruboclean
+  class LoggerTest < BaseTest
+    def test_initialize
+      assert_raises(ArgumentError) do
+        Ruboclean::Logger.new(:invalid)
+      end
+    end
+
+    def test_verbose
+      assert_output(/^message$/) do
+        Ruboclean::Logger.new(:verbose).verbose("message")
+      end
+
+      assert_output(/^$/) do
+        Ruboclean::Logger.new(:none).verbose("message")
+      end
+    end
+  end
+end

--- a/test/ruboclean/runner_test.rb
+++ b/test/ruboclean/runner_test.rb
@@ -92,5 +92,15 @@ module Ruboclean
                      Pathname.new(fixture_path).read
       end
     end
+
+    def test_run_with_verify_flag
+      using_fixture_files("00_input.yml") do |fixture_path|
+        arguments = [fixture_path, "--verify"]
+        Ruboclean::Runner.new(arguments).run!
+
+        assert_equal fixture_file_path("00_input.yml").read,
+                     Pathname.new(fixture_path).read
+      end
+    end
   end
 end

--- a/test/ruboclean/runner_test.rb
+++ b/test/ruboclean/runner_test.rb
@@ -6,7 +6,7 @@ module Ruboclean
   class RunnerTest < BaseTest
     def test_run_without_arguments
       using_fixture_files("00_input.yml") do |fixture_path, directory_path|
-        Dir.chdir(directory_path) do
+        changed = Dir.chdir(directory_path) do
           Ruboclean::Runner.new.run!
         end
 
@@ -14,6 +14,7 @@ module Ruboclean
           fixture_file_path("00_expected_output.yml").read,
           Pathname.new(fixture_path).read
         )
+        assert changed
       end
     end
 
@@ -38,6 +39,20 @@ module Ruboclean
           fixture_file_path("00_expected_output.yml").read,
           Pathname.new(fixture_path).read
         )
+      end
+    end
+
+    def test_return_value_when_already_sorted
+      using_fixture_files("00_expected_output.yml") do |fixture_path, directory_path|
+        changed = Dir.chdir(directory_path) do
+          Ruboclean::Runner.new.run!
+        end
+
+        assert_equal(
+          fixture_file_path("00_expected_output.yml").read,
+          Pathname.new(fixture_path).read
+        )
+        refute changed
       end
     end
 

--- a/test/ruboclean_test.rb
+++ b/test/ruboclean_test.rb
@@ -30,4 +30,24 @@ class RubocleanTest < BaseTest
 
     assert_equal 0, exit_code
   end
+
+  def test_run_from_cli_with_verify_option_when_no_changes
+    exit_code = assert_raises(SystemExit) do
+      using_fixture_files("00_expected_output.yml") do |fixture_path|
+        Ruboclean.run_from_cli!([fixture_path, "--silent", "--verify"])
+      end
+    end.status
+
+    assert_equal 0, exit_code
+  end
+
+  def test_run_from_cli_with_verify_option
+    exit_code = assert_raises(SystemExit) do
+      using_fixture_files("00_input.yml") do |fixture_path|
+        Ruboclean.run_from_cli!([fixture_path, "--silent", "--verify"])
+      end
+    end.status
+
+    assert_equal 1, exit_code
+  end
 end

--- a/test/ruboclean_test.rb
+++ b/test/ruboclean_test.rb
@@ -8,27 +8,27 @@ class RubocleanTest < BaseTest
   end
 
   def test_run_from_cli_without_silent_option
-    exit_code = assert_raises(SystemExit) do
-      using_fixture_files("02_input_empty.yml") do |fixture_path|
-        assert_output(/^Using path '.*' \.\.\. done.$/) do
+    using_fixture_files("02_input_empty.yml") do |fixture_path|
+      assert_output(/^Using path '.*' \.\.\. done.$/) do
+        exit_code = assert_raises(SystemExit) do
           Ruboclean.run_from_cli!([fixture_path])
-        end
-      end
-    end.status
+        end.status
 
-    assert_equal 0, exit_code
+        assert_equal 0, exit_code
+      end
+    end
   end
 
   def test_run_from_cli_with_silent_option
-    exit_code = assert_raises(SystemExit) do
-      using_fixture_files("02_input_empty.yml") do |fixture_path|
-        assert_output(/^$/) do
+    using_fixture_files("02_input_empty.yml") do |fixture_path|
+      assert_output(/^$/) do
+        exit_code = assert_raises(SystemExit) do
           Ruboclean.run_from_cli!([fixture_path, "--silent"])
-        end
-      end
-    end.status
+        end.status
 
-    assert_equal 0, exit_code
+        assert_equal 0, exit_code
+      end
+    end
   end
 
   def test_run_from_cli_with_verify_option_when_no_changes

--- a/test/ruboclean_test.rb
+++ b/test/ruboclean_test.rb
@@ -32,13 +32,15 @@ class RubocleanTest < BaseTest
   end
 
   def test_run_from_cli_with_verify_option_when_no_changes
-    exit_code = assert_raises(SystemExit) do
-      using_fixture_files("00_expected_output.yml") do |fixture_path|
-        Ruboclean.run_from_cli!([fixture_path, "--silent", "--verify"])
-      end
-    end.status
+    using_fixture_files("00_expected_output.yml") do |fixture_path|
+      assert_output(/^Using path '.*' \.\.\. done.$/) do
+        exit_code = assert_raises(SystemExit) do
+          Ruboclean.run_from_cli!([fixture_path, "--verify"])
+        end.status
 
-    assert_equal 0, exit_code
+        assert_equal 0, exit_code
+      end
+    end
   end
 
   def test_run_from_cli_with_verify_option

--- a/test/ruboclean_test.rb
+++ b/test/ruboclean_test.rb
@@ -9,7 +9,7 @@ class RubocleanTest < BaseTest
 
   def test_run_from_cli_without_silent_option
     using_fixture_files("02_input_empty.yml") do |fixture_path|
-      assert_output(/^Using path '.*' \.\.\. done.$/) do
+      assert_output(/^Using path '.*' \.\.\. already clean.$/) do
         exit_code = assert_raises(SystemExit) do
           Ruboclean.run_from_cli!([fixture_path])
         end.status
@@ -33,7 +33,7 @@ class RubocleanTest < BaseTest
 
   def test_run_from_cli_with_verify_option_when_no_changes
     using_fixture_files("00_expected_output.yml") do |fixture_path|
-      assert_output(/^Using path '.*' \.\.\. done.$/) do
+      assert_output(/^Using path '.*' \.\.\. already clean.$/) do
         exit_code = assert_raises(SystemExit) do
           Ruboclean.run_from_cli!([fixture_path, "--verify"])
         end.status
@@ -44,12 +44,14 @@ class RubocleanTest < BaseTest
   end
 
   def test_run_from_cli_with_verify_option
-    exit_code = assert_raises(SystemExit) do
-      using_fixture_files("00_input.yml") do |fixture_path|
-        Ruboclean.run_from_cli!([fixture_path, "--silent", "--verify"])
-      end
-    end.status
+    using_fixture_files("00_input.yml") do |fixture_path|
+      assert_output(/^Using path '.*' \.\.\. needs clean.$/) do
+        exit_code = assert_raises(SystemExit) do
+          Ruboclean.run_from_cli!([fixture_path, "--verify"])
+        end.status
 
-    assert_equal 1, exit_code
+        assert_equal 1, exit_code
+      end
+    end
   end
 end

--- a/test/ruboclean_test.rb
+++ b/test/ruboclean_test.rb
@@ -8,18 +8,26 @@ class RubocleanTest < BaseTest
   end
 
   def test_run_from_cli_without_silent_option
-    using_fixture_files("02_input_empty.yml") do |fixture_path|
-      assert_output(/^Using path '.*' \.\.\. done.$/) do
-        Ruboclean.run_from_cli!([fixture_path])
+    exit_code = assert_raises(SystemExit) do
+      using_fixture_files("02_input_empty.yml") do |fixture_path|
+        assert_output(/^Using path '.*' \.\.\. done.$/) do
+          Ruboclean.run_from_cli!([fixture_path])
+        end
       end
-    end
+    end.status
+
+    assert_equal 0, exit_code
   end
 
   def test_run_from_cli_with_silent_option
-    using_fixture_files("02_input_empty.yml") do |fixture_path|
-      assert_output(/^$/) do
-        Ruboclean.run_from_cli!([fixture_path, "--silent"])
+    exit_code = assert_raises(SystemExit) do
+      using_fixture_files("02_input_empty.yml") do |fixture_path|
+        assert_output(/^$/) do
+          Ruboclean.run_from_cli!([fixture_path, "--silent"])
+        end
       end
-    end
+    end.status
+
+    assert_equal 0, exit_code
   end
 end


### PR DESCRIPTION
I implemented `--verify` flag. Can you please review and merge this?

With this flag, ruboclean acts like below.
- Do not write result to file.
- exit with 1, when `.rubocop.yml` has changes.
- exit with 0, when `.rubocop.yml` has no changes.

For backward compatibility, it exit with 0 when `--verify` flag is not passed.

closes #38. 