### PR TITLE
bump version to 0.8.0

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -1,7 +1,7 @@
 PATH
   remote: .
   specs:
-    ruboclean (0.7.1)
+    ruboclean (0.8.0)
 
 GEM
   remote: https://rubygems.org/
@@ -88,7 +88,7 @@ CHECKSUMS
   rainbow (3.1.1) sha256=039491aa3a89f42efa1d6dec2fc4e62ede96eb6acd95e52f1ad581182b79bc6a
   rake (13.4.2) sha256=cb825b2bd5f1f8e91ca37bddb4b9aaf345551b4731da62949be002fa89283701
   regexp_parser (2.12.0) sha256=35a916a1d63190ab5c9009457136ae5f3c0c7512d60291d0d1378ba18ce08ebb
-  ruboclean (0.7.1)
+  ruboclean (0.8.0)
   rubocop (1.86.2) sha256=bb2e97f635eda42c448f2588f4a6ff78f221b8bdfdf65b1e9b07fbd57521b45d
   rubocop-ast (1.49.1) sha256=4412f3ee70f6fe4546cc489548e0f6fcf76cafcfa80fa03af67098ffed755035
   rubocop-minitest (0.39.1) sha256=998398d6da4026d297f0f9bf709a1eac5f2b6947c24431f94af08138510cf7ed

--- a/lib/ruboclean/version.rb
+++ b/lib/ruboclean/version.rb
@@ -1,5 +1,5 @@
 # frozen_string_literal: true
 
 module Ruboclean
-  VERSION = "0.7.1"
+  VERSION = "0.8.0"
 end


### PR DESCRIPTION
ruboclean version 0.8.0 changes the minimum Ruby version to >= 3.3.

End of Life for Ruby 3.2 has been reached on March 31st 2026.